### PR TITLE
Update stringify function in README to mirror linkQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,23 +123,19 @@ If you need to stringify these you can use the following algo:
 
 ```js
 const stringify = (title, metas, links) => {
-  const visited = new Set();
+  const stringifyTag = (tagName, tags) =>
+    tags.reduce((acc, tag) => {
+      `${acc}<${tagName}${Object.keys(tag).reduce(
+        (properties, key) => `${properties} ${key}="${tag[key]}"`,
+        ''
+      )}>`
+    }, '')
+
   return `
     <title>${title}</title>
 
-    ${metas.reduce((acc, meta) => {
-      return `${acc}<meta${Object.keys(meta).reduce(
-        (properties, key) => `${properties} ${key}="${meta[key]}"`,
-        ''
-      )}>`
-    }, '')}
-
-    ${links.reduce((acc, link) => {
-      return `${acc}<link${Object.keys(link).reduce(
-        (properties, key) => `${properties} ${key}="${link[key]}"`,
-        ''
-      )}>`;
-    }, '')}
+    ${stringifyTag('meta', metas)}
+    ${stringifyTag('link', links)}
   `;
 };
 ```

--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ const stringify = (title, metas, links) => {
   return `
     <title>${title}</title>
 
-    ${metaQueue.reduce((acc, meta) => {
+    ${metas.reduce((acc, meta) => {
       return `${acc}<meta${Object.keys(meta).reduce(
         (properties, key) => `${properties} ${key}="${meta[key]}"`,
         ''
       )}>`
     }, '')}
 
-    ${linkQueue.reduce((acc, link) => {
+    ${links.reduce((acc, link) => {
       return `${acc}<link${Object.keys(link).reduce(
         (properties, key) => `${properties} ${key}="${link[key]}"`,
         ''

--- a/README.md
+++ b/README.md
@@ -128,13 +128,10 @@ const stringify = (title, metas, links) => {
     <title>${title}</title>
 
     ${metaQueue.reduce((acc, meta) => {
-      if (!visited.has(meta.charset ? meta.keyword : meta[meta.keyword])) {
-        visited.add(meta.charset ? meta.keyword : meta[meta.keyword]);
-        return `${acc}<meta ${meta.keyword}="${meta[meta.keyword]}"${
-          meta.charset ? '' : ` content="${meta.content}"`
-        }>`;
-      }
-      return acc;
+      return `${acc}<meta${Object.keys(meta).reduce(
+        (properties, key) => `${properties} ${key}="${meta[key]}"`,
+        ''
+      )}>`
     }, '')}
 
     ${linkQueue.reduce((acc, link) => {


### PR DESCRIPTION
I noticed that the `metaQueue` return type appears to have changed, to basically mirror what's expected for the `linkQueue`. Thus, I've reflected the same logic here in the README