### PR TITLE
Guard against no meta tags being returned in React Concurrent Mode

### DIFF
--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -161,7 +161,9 @@ export const createDispatcher = () => {
                 : `meta[${oldMeta.keyword}="${oldMeta[oldMeta.keyword]}"]`
             );
 
-            document.head.removeChild(result[0]);
+            if (result[0) {
+              document.head.removeChild(result[0]);
+            }
           }
         }
       }

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -161,7 +161,7 @@ export const createDispatcher = () => {
                 : `meta[${oldMeta.keyword}="${oldMeta[oldMeta.keyword]}"]`
             );
 
-            if (result[0) {
+            if (result[0]) {
               document.head.removeChild(result[0]);
             }
           }


### PR DESCRIPTION
Fixes #75 

I'm simply guarding against `result[0]` not being available.

As described in the issue, I believe React Concurrent Mode is removing the Meta tag while concurrently re-running `useMeta` which believes it's there

I could be wrong in my assumption of the problem. But overall, this seems to fix it for me!