### PR TITLE
Use #x27 instead of &#39 to escape single quotes

### DIFF
--- a/.changeset/stupid-bananas-hang.md
+++ b/.changeset/stupid-bananas-hang.md
@@ -1,0 +1,5 @@
+---
+'hoofd': minor
+---
+
+Escape single quotes via x27 instead of 39

--- a/__tests__/ssr.test.tsx
+++ b/__tests__/ssr.test.tsx
@@ -80,7 +80,7 @@ describe('ssr', () => {
 
     expect(metas).toEqual([
       { content: '&quot;&quot;', property: 'fb:something' },
-      { content: '&#39;&#39;&lt;&gt;&amp;', property: 'fb:admins' },
+      { content: '&#x27;&#x27;&lt;&gt;&amp;', property: 'fb:admins' },
     ]);
   });
 

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -220,7 +220,7 @@ export const createDispatcher = () => {
               ch = '&amp;';
               break;
             case 39:
-              ch = '&#39;';
+              ch = '&#x27;';
               break;
             case 60:
               ch = '&lt;';


### PR DESCRIPTION
During our testing, I noticed that `&#39;` appears in the rendered content when escaping `'`. Looking elsewhere, we see them escaping with `&#x27;` instead. This PR replaces the former with the latter with the hope that it renders `'` correctly