### PR TITLE
use an object to keep integrity

### DIFF
--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -1,22 +1,27 @@
 import { useContext, useEffect, useRef } from 'react';
-import { DispatcherContext, TEMPLATE, TITLE } from '../dispatcher';
+import {
+  DispatcherContext,
+  TEMPLATE,
+  TITLE,
+  TitlePayload,
+} from '../dispatcher';
 import { isServerSide } from '../utils';
 
 export const useTitle = (title: string, template?: boolean) => {
   const dispatcher = useContext(DispatcherContext);
   const hasMounted = useRef(false);
-  const prevTitle = useRef<string | undefined>();
+  const prevTitle = useRef<{ payload: string } | undefined>();
 
   if (isServerSide && !hasMounted.current) {
-    dispatcher._addToQueue(template ? TEMPLATE : TITLE, title);
+    dispatcher._addToQueue(template ? TEMPLATE : TITLE, { payload: title });
   }
 
   useEffect(() => {
     if (hasMounted.current) {
       dispatcher._change(
         template ? TEMPLATE : TITLE,
-        prevTitle.current as string,
-        (prevTitle.current = title)
+        prevTitle.current as TitlePayload,
+        (prevTitle.current = { payload: title })
       );
     }
   }, [title, template]);
@@ -25,14 +30,14 @@ export const useTitle = (title: string, template?: boolean) => {
     hasMounted.current = true;
     dispatcher._addToQueue(
       template ? TEMPLATE : TITLE,
-      (prevTitle.current = title)
+      (prevTitle.current = { payload: title })
     );
 
     return () => {
       hasMounted.current = false;
       dispatcher._removeFromQueue(
         template ? TEMPLATE : TITLE,
-        prevTitle.current as string
+        prevTitle.current as TitlePayload
       );
     };
   }, [template]);


### PR DESCRIPTION
Attempt at resolving #90 

This changes `useTitle` and `useTitleTemplate` to leverage an object in the queue rather than a primitive value in the hopes that when we keep our previous value we will more accurately remove and replace it in the queue when interrupts/suspensions happen.