### PR TITLE
Fix tag stringification example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ If you need to stringify these you can use the following algo:
 ```js
 const stringify = (title, metas, links) => {
   const stringifyTag = (tagName, tags) =>
-    tags.reduce((acc, tag) => {
+    tags.reduce((acc, tag) => 
       `${acc}<${tagName}${Object.keys(tag).reduce(
         (properties, key) => `${properties} ${key}="${tag[key]}"`,
         ''
-      )}>`;
-    }, '');
+      )}>`
+    , '');
 
   return `
     <title>${title}</title>


### PR DESCRIPTION
Whilst setting up SSR for our app, I discovered a slight error in the example code for meta tag stringification. The extra set of brackets means that the inner reduce call never returns anything, just undefined. Removing the extra brackets makes the stringification work like a charm 🙌 

Also, thanks so much for a great library! This will probably end up replacing our current rig with `react-helmet-async`.