### PR TITLE
fix(useScript): variable scope bug that stops scripts being unmounted

### DIFF
--- a/.changeset/blue-swans-kick.md
+++ b/.changeset/blue-swans-kick.md
@@ -2,4 +2,4 @@
 "hoofd": patch
 ---
 
-fix(useScript): variable scope bug that stops scripts being unmounted
+Correct variable scoping in the `useEffect` of `useScript`, this prevents scripts from being wrongly unmounted

--- a/.changeset/blue-swans-kick.md
+++ b/.changeset/blue-swans-kick.md
@@ -1,0 +1,5 @@
+---
+"hoofd": patch
+---
+
+fix(useScript): variable scope bug that stops scripts being unmounted

--- a/__tests__/useScript.test.tsx
+++ b/__tests__/useScript.test.tsx
@@ -26,9 +26,14 @@ describe('useScript', () => {
     act(() => {
       render(<MyComponent />);
     });
-    expect(document.head.innerHTML).toContain(
-      '<script type="application/javascript" crossorigin="anonymous" async="true" src="test.js"></script>'
-    );
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/javascript');
+    expect(scripts[0].crossOrigin).to.equal('anonymous');
+    expect(scripts[0].src).toContain('test.js');
+    expect(scripts[0].getAttribute('async')).to.equal('true');
   });
 
   it('should reuse an existing tag', () => {
@@ -57,9 +62,58 @@ describe('useScript', () => {
     act(() => {
       render(<MyComponent />);
     });
-    expect(document.head.innerHTML).toContain(
-      '<script type="application/javascript" crossorigin="anonymous" async="true" src="test.js"></script>'
-    );
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/javascript');
+    expect(scripts[0].crossOrigin).to.equal('anonymous');
+    expect(scripts[0].src).toContain('test.js');
+    expect(scripts[0].getAttribute('async')).to.equal('true');
+  });
+
+  it('should create a new tag when the existing tag with src is not found', () => {
+    const MyComponent = () => {
+      useScript({
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'another-test.js',
+        async: true,
+      });
+      return <p>hi</p>;
+    };
+
+    const node = document.createElement('script');
+    const options = {
+      crossorigin: 'anonymous',
+      src: 'first-test.js',
+      async: true,
+    };
+    Object.keys(options).forEach(key => {
+      // @ts-ignore
+      (node as Element).setAttribute(key, options[key]);
+    });
+    document.head.appendChild(node);
+
+    act(() => {
+      render(<MyComponent />);
+    });
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(2);
+    expect(scripts[0].type).to.equal('');
+    expect(scripts[0].crossOrigin).to.equal('anonymous');
+    expect(scripts[0].src).toContain('first-test.js');
+    expect(scripts[0].getAttribute('async')).to.equal('true');
+
+    expect(scripts[1].type).to.equal('application/javascript');
+    expect(scripts[1].crossOrigin).to.equal('anonymous');
+    expect(scripts[1].src).toContain('another-test.js');
+    expect(scripts[1].getAttribute('async')).to.equal('true');
+
+    // cleanup only removes elements added/modified through React
+    document.head.removeChild(node);
   });
 
   it('should fill in the script with text', () => {
@@ -76,9 +130,11 @@ describe('useScript', () => {
       render(<MyComponent />);
     });
 
-    expect(document.head.innerHTML).toContain(
-      '<script type="application/ld+json" id="rich-text">{"key":"value"}</script>'
-    );
+    const scripts = document.head.querySelectorAll('script');
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/ld+json');
+    expect(scripts[0].id).to.equal('rich-text');
+    expect(scripts[0].text).to.equal('{"key":"value"}');
   });
 
   it('should reuse an existing tag to fill text', () => {
@@ -106,8 +162,50 @@ describe('useScript', () => {
       render(<MyComponent />);
     });
 
-    expect(document.head.innerHTML).toContain(
-      '<script type="application/ld+json" id="rich-text">{"key":"value"}</script>'
-    );
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/ld+json');
+    expect(scripts[0].id).to.equal('rich-text');
+    expect(scripts[0].text).to.equal('{"key":"value"}');
+  });
+
+  it('should create a new tag when existing tag id does not match', () => {
+    const MyComponent = () => {
+      useScript({
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'richer-text',
+      });
+      return <p>hi</p>;
+    };
+
+    const node = document.createElement('script');
+    const options = {
+      type: 'application/ld+json',
+      id: 'empty-rich-text',
+    };
+    Object.keys(options).forEach(key => {
+      // @ts-ignore
+      (node as Element).setAttribute(key, options[key]);
+    });
+    document.head.appendChild(node);
+
+    act(() => {
+      render(<MyComponent />);
+    });
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(2);
+    expect(scripts[0].type).to.equal('application/ld+json');
+    expect(scripts[0].id).to.equal('empty-rich-text');
+    expect(scripts[0].text).to.equal('');
+    expect(scripts[1].type).to.equal('application/ld+json');
+    expect(scripts[1].id).to.equal('richer-text');
+    expect(scripts[1].text).to.equal('{"key":"value"}');
+
+    // cleanup only removes elements added/modified through React
+    document.head.removeChild(node);
   });
 });

--- a/__tests__/useScript.test.tsx
+++ b/__tests__/useScript.test.tsx
@@ -116,6 +116,82 @@ describe('useScript', () => {
     document.head.removeChild(node);
   });
 
+  it('should remove script on unmount', () => {
+    const MyComponent = () => {
+      useScript({
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      });
+      return <p>hi</p>;
+    };
+
+    let unmount;
+
+    act(() => {
+      unmount = render(<MyComponent />).unmount;
+    });
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/javascript');
+    expect(scripts[0].crossOrigin).to.equal('anonymous');
+    expect(scripts[0].src).toContain('test.js');
+    expect(scripts[0].getAttribute('async')).to.equal('true');
+
+    unmount();
+
+    const updatedScripts = document.head.querySelectorAll('script');
+
+    expect(updatedScripts.length).to.equal(0);
+  });
+
+  it('should remove reused script on unmount', () => {
+    const MyComponent = () => {
+      useScript({
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      });
+      return <p>hi</p>;
+    };
+
+    const node = document.createElement('script');
+    const options = {
+      crossorigin: 'anonymous',
+      src: 'test.js',
+      async: true,
+    };
+    Object.keys(options).forEach(key => {
+      // @ts-ignore
+      (node as Element).setAttribute(key, options[key]);
+    });
+    document.head.appendChild(node);
+
+    let unmount;
+
+    act(() => {
+      unmount = render(<MyComponent />).unmount;
+    });
+
+    const scripts = document.head.querySelectorAll('script');
+
+    expect(scripts.length).to.equal(1);
+    expect(scripts[0].type).to.equal('application/javascript');
+    expect(scripts[0].crossOrigin).to.equal('anonymous');
+    expect(scripts[0].src).toContain('test.js');
+    expect(scripts[0].getAttribute('async')).to.equal('true');
+
+    unmount();
+
+    const updatedScripts = document.head.querySelectorAll('script');
+
+    expect(updatedScripts.length).to.equal(0);
+  });
+
   it('should fill in the script with text', () => {
     const MyComponent = () => {
       useScript({

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -30,26 +30,28 @@ export const useScript = (options: ScriptOptions) => {
 
     if (!preExistingElements[0] && (options.src || options.id)) {
       script = document.createElement('script');
-
-      if (options.type) script.type = options.type;
-      if (options.module) script.type = 'module';
-
-      if (options.integrity)
-        script.setAttribute('integrity', options.integrity as string);
-      if (options.crossorigin)
-        script.setAttribute('crossorigin', options.crossorigin as string);
-      if (options.defer) script.setAttribute('defer', 'true');
-      else if (options.async) script.setAttribute('async', 'true');
-
-      if (options.id) script.id = options.id;
-
-      if (options.src) script.src = options.src;
-
-      if (options.text) script.text = options.text;
-
-      document.head.appendChild(script);
     } else if (preExistingElements[0]) {
       script = preExistingElements[0] as HTMLScriptElement;
+    }
+
+    if (options.type) script.type = options.type;
+    if (options.module) script.type = 'module';
+
+    if (options.integrity)
+      script.setAttribute('integrity', options.integrity as string);
+    if (options.crossorigin)
+      script.setAttribute('crossorigin', options.crossorigin as string);
+    if (options.defer) script.setAttribute('defer', 'true');
+    else if (options.async) script.setAttribute('async', 'true');
+
+    if (options.id) script.id = options.id;
+
+    if (options.src) script.src = options.src;
+
+    if (options.text) script.text = options.text;
+
+    if (!preExistingElements[0] && (options.src || options.id)) {
+      document.head.appendChild(script);
     }
 
     return () => {

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -28,10 +28,10 @@ export const useScript = (options: ScriptOptions) => {
 
     let script: HTMLScriptElement;
 
-    if (!preExistingElements[0] && (options.src || options.id)) {
-      script = document.createElement('script');
-    } else if (preExistingElements[0]) {
+    if (preExistingElements[0]) {
       script = preExistingElements[0] as HTMLScriptElement;
+    } else {
+      script = document.createElement('script');
     }
 
     if (options.type) script.type = options.type;
@@ -50,7 +50,7 @@ export const useScript = (options: ScriptOptions) => {
 
     if (options.text) script.text = options.text;
 
-    if (!preExistingElements[0] && (options.src || options.id)) {
+    if (!preExistingElements[0]) {
       document.head.appendChild(script);
     }
 

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -29,7 +29,7 @@ export const useScript = (options: ScriptOptions) => {
     let script: HTMLScriptElement;
 
     if (!preExistingElements[0] && (options.src || options.id)) {
-      const script = document.createElement('script');
+      script = document.createElement('script');
 
       if (options.type) script.type = options.type;
       if (options.module) script.type = 'module';


### PR DESCRIPTION
I ran into this bug when testing for scripts being removed from the DOM. 

When the script element is first created (L32) it was not assigned to the `script` variable that the useEffect return function is using to remove the element (L57)